### PR TITLE
fix: Fix `Iterator` declaration

### DIFF
--- a/src/factory-stubs/declarations.pyi
+++ b/src/factory-stubs/declarations.pyi
@@ -84,7 +84,7 @@ class Iterator(Generic[S, V], BaseDeclaration[Any, V]):
     iterator_builder: Callable[[], utils.ResetableIterator[S]]
     def __init__(
         self,
-        iterator: typing.Iterator[T],
+        iterator: typing.Iterable[T],
         cycle: bool = ...,
         getter: Callable[[T], V] | None = ...,
     ): ...

--- a/src/factory-stubs/declarations.pyi
+++ b/src/factory-stubs/declarations.pyi
@@ -13,7 +13,7 @@ from typing import (
     TypeVar,
 )
 
-from . import base, utils, builder
+from . import base, builder, utils
 
 T = TypeVar("T")  # Type of the instance
 V = TypeVar("V")  # Type of the attribute
@@ -80,7 +80,7 @@ class SelfAttribute(BaseDeclaration[T, V]):
 
 class Iterator(Generic[S, V], BaseDeclaration[Any, V]):
     getter: Callable[[S], V] | None
-    iterator: utils.ResetableIterator[typing.Iterator[S]] | None
+    iterator: utils.ResetableIterator[S] | None
     iterator_builder: Callable[[], utils.ResetableIterator[S]]
     def __init__(
         self,

--- a/src/factory-stubs/utils.pyi
+++ b/src/factory-stubs/utils.pyi
@@ -25,7 +25,7 @@ class log_pprint:
     ) -> None: ...
 
 class ResetableIterator(Generic[T]):
-    iterator: Iterable[T]
+    iterator: Iterator[T]
     past_elements: collections.deque[T]
     next_elements: collections.deque[T]
     def __init__(self, iterator: Iterable[T], **kwargs: Any) -> None: ...


### PR DESCRIPTION
This should be `Iterable`, not `Iterator` to accept any iterable object, such as lists, enums, etc ...