### PR TITLE
Bind generic type argument to Iterator.__init__()

### DIFF
--- a/src/factory-stubs/declarations.pyi
+++ b/src/factory-stubs/declarations.pyi
@@ -85,9 +85,9 @@ class Iterator(Generic[S, V], BaseDeclaration[Any, V]):
     iterator_builder: Callable[[], utils.ResetableIterator[S]]
     def __init__(
         self,
-        iterator: typing.Iterable[T],
+        iterator: typing.Iterable[S],
         cycle: bool = ...,
-        getter: Callable[[T], V] | None = ...,
+        getter: Callable[[S], V] | None = ...,
     ): ...
     def reset(self) -> None: ...
 


### PR DESCRIPTION
This is somewhat of a drive-by PR, so I hope that I have not misunderstood these type annotations, but I think that this should be an improvement. The type variable `T` should be identical to `S` in the constructor of `Iterator.__init__()`, so we can use it in order to bind the correct types.

If you need more context, I can try to provide it :)

Thanks in advance!
